### PR TITLE
Add imports for client and host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+bower_components
+node_modules
+
+*.log
+*.swp
+*.swo

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # ifrau-import
-ifrau-import provides a versioned HTML import of ifrau.
+`ifrau-import` provides a versioned HTML import of [`ifrau`](https://github.com/Brightspace/ifrau).
+
+## Usage
+
+
+```html
+<!-- probably what you're looking for -->
+<link rel="import" href="/path/to/ifrau-import/ifrau-client.html">
+```
+
+or 
+
+```html
+<!-- actually hosting a FRA on your page? grab the host -->
+<link rel="import" href="/path/to/ifrau-import/ifrau-host.html">
+```

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,13 @@
+{
+	"name": "ifrua-import",
+	"description": "An HTML import for https://github.com/Brightspace/ifrau",
+	"authors": [
+	  "D2L Corporation"
+	],
+	"license": "Apache-2.0",
+	"homepage": "https://github.com/Brightspace/ifrau-import",
+	"ignore": [
+	  "**/.*",
+	  "bower_components"
+	]
+  }

--- a/ifrau-client.html
+++ b/ifrau-client.html
@@ -1,0 +1,1 @@
+<script src="https://s.brightspace.com/lib/ifrau/0.24.1/ifrau/client.js"></script>

--- a/ifrau-host.html
+++ b/ifrau-host.html
@@ -1,0 +1,1 @@
+<script src="https://s.brightspace.com/lib/ifrau/0.24.1/ifrau/host.js"></script>


### PR DESCRIPTION
The newer versions of polymer-cli be [doin' this](https://travis-ci.org/Brightspace/user-switcher/builds/407179675#L3921) when they encounter direct script tags. This import will let us maybe trick the linter until we get to Polymer 3 and beyond.

![image](https://user-images.githubusercontent.com/2243995/43089104-779f55ca-8e69-11e8-8fa3-dd2eab1eadd7.png)
